### PR TITLE
Fix Case Sensitive Errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.md
 AMPS/Includer.exe.config
 AMPS/Includer.pdb
+AMPS/.Data

--- a/AMPS/code/68k Commands.asm
+++ b/AMPS/code/68k Commands.asm
@@ -919,7 +919,7 @@ dUpdateVoiceFM:
 	if safe=1
 		AMPS_Debug_CuePtr 0		; make sure cue is valid
 	endif
-	StopZ80					; wait for Z80 to stop
+	stopZ80					; wait for Z80 to stop
 
 .write
 	rept VoiceRegs+1
@@ -929,7 +929,7 @@ dUpdateVoiceFM:
 	endr
 
 	;	st	(a0)			; mark as end of the cue
-	StartZ80				; enable Z80 execution
+	startZ80				; enable Z80 execution
 		move.l	a5,sp			; fix stack pointer
 		bclr	#cfbVol,(a1)		; reset volume update request flag
 		move.l	(sp)+,a2		; load the tracker address from stack

--- a/AMPS/code/68k DAC Routines.asm
+++ b/AMPS/code/68k DAC Routines.asm
@@ -143,13 +143,13 @@ dNoteWriteDAC1:
 		lea	dZ80+PCM1_NewRET,a4	; ''
 
 dNoteOnDAC4:
-	StopZ80					; wait for Z80 to stop
+	stopZ80					; wait for Z80 to stop
 	rept 12
 		move.b	(a2)+,(a5)+		; send sample data to Dual PCM
 	endr
 
 		move.b	#$DA,(a4)		; activate sample switch (change instruction)
-	StartZ80				; enable Z80 execution
+	startZ80				; enable Z80 execution
 
 locret_dNoteOnDAC4:
 		rts
@@ -214,21 +214,21 @@ dUpdateFreqDAC3:
 		btst	#ctbPt2,cType(a1)	; check if DAC1
 		beq.s	dFreqDAC1		; if is, branch
 
-	StopZ80					; wait for Z80 to stop
+	stopZ80					; wait for Z80 to stop
 		move.b	d2,dZ80+PCM2_PitchHigh+1
 		move.b	d3,dZ80+PCM2_PitchLow+1
 		move.b	#$D2,dZ80+PCM2_ChangePitch; change "JP C" to "JP NC"
-	StartZ80				; enable Z80 execution
+	startZ80				; enable Z80 execution
 
 locret_UpdFreqDAC;
 		rts
 
 dFreqDAC1:
-	StopZ80					; wait for Z80 to stop
+	stopZ80					; wait for Z80 to stop
 		move.b	d2,dZ80+PCM1_PitchHigh+1
 		move.b	d3,dZ80+PCM1_PitchLow+1
 		move.b	#$D2,dZ80+PCM1_ChangePitch; change "JP C" to "JP NC"
-	StartZ80				; enable Z80 execution
+	startZ80				; enable Z80 execution
 		rts
 ; ===========================================================================
 ; ---------------------------------------------------------------------------
@@ -350,18 +350,18 @@ dUpdateVolDAC2:
 		and.b	#$80,d1			; change volume of $FF to $80 (this mutes DAC)
 
 .nocap
-	StopZ80					; wait for Z80 to stop
+	stopZ80					; wait for Z80 to stop
 		move.b	#$D2,dZ80+PCM_ChangeVolume; set volume change flag
 
 		btst	#ctbPt2,cType(a1)	; check if this channel is DAC1
 		beq.s	.dac1			; if is, branch
 		move.b	d1,dZ80+PCM2_Volume+1	; save volume for PCM 1
-	StartZ80				; enable Z80 execution
+	startZ80				; enable Z80 execution
 		rts
 
 .dac1
 		move.b	d1,dZ80+PCM1_Volume+1	; save volume for PCM 2
-	StartZ80				; enable Z80 execution
+	startZ80				; enable Z80 execution
 
 locret_VolDAC:
 		rts

--- a/AMPS/code/68k Main.asm
+++ b/AMPS/code/68k Main.asm
@@ -138,7 +138,7 @@ dLoadFade:
 dSetFilter:
 		lea	dZ80+SV_VolumeBank.l,a4	; load volume bank instructions address to a1
 		moveq	#$74,d5			; prepare the "ld  (hl),h" instruction to d1
-	StopZ80					; wait for Z80 to stop
+	stopZ80					; wait for Z80 to stop
 ; ---------------------------------------------------------------------------
 ; addx in Motorola 68000 is much like adc in Z80. It allows us to add
 ; a register AND the carry to another register. What this means, is if
@@ -155,7 +155,7 @@ dSetFilter:
 		move.b	d6,(a4)+		; save instruction into Z80 memory
 	endr
 
-	StartZ80				; enable Z80 execution
+	startZ80				; enable Z80 execution
 
 locret_SetFilter:
 		rts

--- a/AMPS/code/68k PlaySnd.asm
+++ b/AMPS/code/68k PlaySnd.asm
@@ -66,7 +66,7 @@ dPlaySnd_Pause:
 ; ---------------------------------------------------------------------------
 
 dMuteDAC:
-	StopZ80					; wait for Z80 to stop
+	stopZ80					; wait for Z80 to stop
 		lea	SampleList(pc),a5	; load address for the stop sample data into a2
 		lea	dZ80+PCM1_Sample,a4	; load addresses for PCM 1 sample to a1
 
@@ -83,7 +83,7 @@ dMuteDAC:
 
 		move.b	#$CA,dZ80+PCM1_NewRET	; activate sample switch (change instruction)
 		move.b	#$CA,dZ80+PCM2_NewRET	; activate sample switch (change instruction)
-	StartZ80				; enable Z80 execution
+	startZ80				; enable Z80 execution
 
 locret_MuteDAC:
 		rts

--- a/AMPS/code/Data.asm
+++ b/AMPS/code/Data.asm
@@ -102,7 +102,7 @@ SampleList:
 	sample $0100, KcTom, Stop		; 91 - Tom (Knuckles Chaotix)
 	sample $00C0, KcTom, Stop, KcLowTom	; 92 - Low Tom (Knuckles Chaotix)
 	sample $0080, KcTom, Stop, KcFloorTom	; 93 - Floor Tom (Knuckles Chaotix)
-	sample $0100, kcCymbal, Stop		; 94 - Cymbal? (Knuckles Chaotix)
+	sample $0100, KcCymbal, Stop		; 94 - Cymbal? (Knuckles Chaotix)
 	sample $0100, KcSnare, Stop		; 95 - Snare (Knuckles Chaotix)
 	sample $0100, KcTamb, Stop		; 96 - Tambourine? (Knuckles Chaotix)
 	sample $0100, Kc87, Stop		; 97 - Not really sure? (Knuckles Chaotix)

--- a/AMPS/code/smps2asm.asm
+++ b/AMPS/code/smps2asm.asm
@@ -234,7 +234,7 @@ spTLMask1 =	((spAl=7)<<7)
 
 	dc.b (spDe1<<4)+spMu1, (spDe3<<4)+spMu3, (spDe2<<4)+spMu2, (spDe4<<4)+spMu4
 	dc.b (spRS1<<6)+spAR1, (spRS3<<6)+spAR3, (spRS2<<6)+spAR2, (spRS4<<6)+spAR4
-	dc.b (spAM1<<7)+spSR1, (spAM3<<7)+spsR3, (spAM2<<7)+spSR2, (spAM4<<7)+spSR4
+	dc.b (spAM1<<7)+spSR1, (spAM3<<7)+spSR3, (spAM2<<7)+spSR2, (spAM4<<7)+spSR4
 	dc.b spDR1,            spDR3,            spDR2,            spDR4
 	dc.b (spSL1<<4)+spRR1, (spSL3<<4)+spRR3, (spSL2<<4)+spRR2, (spSL4<<4)+spRR4
 	dc.b spSS1,            spSS3,            spSS2,            spSS4
@@ -255,7 +255,7 @@ spTL4 =		\op4
 	dc.b (spFe<<3)+spAl
 	dc.b (spDe1<<4)+spMu1, (spDe3<<4)+spMu3, (spDe2<<4)+spMu2, (spDe4<<4)+spMu4
 	dc.b (spRS1<<6)+spAR1, (spRS3<<6)+spAR3, (spRS2<<6)+spAR2, (spRS4<<6)+spAR4
-	dc.b (spAM1<<7)+spSR1, (spAM3<<7)+spsR3, (spAM2<<7)+spSR2, (spAM4<<7)+spSR4
+	dc.b (spAM1<<7)+spSR1, (spAM3<<7)+spSR3, (spAM2<<7)+spSR2, (spAM4<<7)+spSR4
 	dc.b spDR1,            spDR3,            spDR2,            spDR4
 	dc.b (spSL1<<4)+spRR1, (spSL3<<4)+spRR3, (spSL2<<4)+spRR2, (spSL4<<4)+spRR4
 	dc.b spSS1,            spSS3,            spSS2,            spSS4

--- a/AMPS/music/Pray.s2a
+++ b/AMPS/music/Pray.s2a
@@ -608,10 +608,10 @@ Pray_Loop2:
 ; 9F - Ristar laughs
 ; A1 - Ristar sound
 
-d9C = nrst
-d9D = nrst
-d9F = nrst
-dA1 = nrst
+d9C = nRst
+d9D = nRst
+d9F = nRst
+dA1 = nRst
 d97 = dSnare
 d87 = dClap
 d88 = dClap

--- a/error/Debugger.asm
+++ b/error/Debugger.asm
@@ -110,7 +110,7 @@ RaiseError2 &
 Console &
 	macro
 
-	if strcmp("\0","Write")|strcmp("\0","WriteLine")
+	if strcmp("\0","Write")|strcmp("\0","WriteLine")|strcmp("\0","write")|strcmp("\0","writeline")
 		move.w	sr, -(sp)
 		__FSTRING_GenerateArgumentsCode \1
 		movem.l	a0-a2/d7, -(sp)
@@ -132,14 +132,14 @@ Console &
 		even
 	.instr_end\@:
 
-	elseif strcmp("\0","Run")
+	elseif strcmp("\0","Run")|strcmp("\0","run")
 		jsr		ErrorHandler.__extern__console_only
 		jsr		\1
 		if narg<=1		; HACK
 			bra.s	*
 		endif
 
-	elseif strcmp("\0","SetXY")
+	elseif strcmp("\0","SetXY")|strcmp("\0","setxy")
 		move.w	sr, -(sp)
 		movem.l	d0-d1, -(sp)
 		move.w	\2, -(sp)
@@ -149,7 +149,7 @@ Console &
 		movem.l	(sp)+, d0-d1
 		move.w	(sp)+, sr
 
-	elseif strcmp("\0","BreakLine")
+	elseif strcmp("\0","BreakLine")|strcmp("\0","breakline")
 		move.w	sr, -(sp)
 		jsr		ErrorHandler.__global__console_StartNewLine
 		move.w	(sp)+, sr

--- a/error/Debugger.asm
+++ b/error/Debugger.asm
@@ -110,7 +110,7 @@ RaiseError2 &
 Console &
 	macro
 
-	if strcmp("\0","write")|strcmp("\0","writeline")
+	if strcmp("\0","Write")|strcmp("\0","WriteLine")
 		move.w	sr, -(sp)
 		__FSTRING_GenerateArgumentsCode \1
 		movem.l	a0-a2/d7, -(sp)
@@ -132,26 +132,26 @@ Console &
 		even
 	.instr_end\@:
 
-	elseif strcmp("\0","run")
+	elseif strcmp("\0","Run")
 		jsr		ErrorHandler.__extern__console_only
 		jsr		\1
 		if narg<=1		; HACK
 			bra.s	*
 		endif
 
-	elseif strcmp("\0","setxy")
+	elseif strcmp("\0","SetXY")
 		move.w	sr, -(sp)
 		movem.l	d0-d1, -(sp)
 		move.w	\2, -(sp)
 		move.w	\1, -(sp)
-		jsr		ErrorHandler.__global__console_setposasxy_stack
+		jsr		ErrorHandler.__global__console_SetPosAsXY_stack
 		addq.w	#4, sp
 		movem.l	(sp)+, d0-d1
 		move.w	(sp)+, sr
 
-	elseif strcmp("\0","breakline")
+	elseif strcmp("\0","BreakLine")
 		move.w	sr, -(sp)
-		jsr		ErrorHandler.__global__console_startnewline
+		jsr		ErrorHandler.__global__console_StartNewLine
 		move.w	(sp)+, sr
 
 	else

--- a/error/ErrorHandler.asm
+++ b/error/ErrorHandler.asm
@@ -71,20 +71,20 @@ ErrorTrap:
 ; Import error handler global functions
 ; ---------------------------------------------------------------
 
-ErrorHandler.__global__error_initconsole equ ErrorHandler+$146
-ErrorHandler.__global__errorhandler_setupvdp equ ErrorHandler+$234
-ErrorHandler.__global__console_loadpalette equ ErrorHandler+$A1C
-ErrorHandler.__global__console_setposasxy_stack equ ErrorHandler+$A58
-ErrorHandler.__global__console_setposasxy equ ErrorHandler+$A5E
-ErrorHandler.__global__console_getposasxy equ ErrorHandler+$A8A
-ErrorHandler.__global__console_startnewline equ ErrorHandler+$AAC
-ErrorHandler.__global__console_setbasepattern equ ErrorHandler+$AD4
-ErrorHandler.__global__console_setwidth equ ErrorHandler+$AE8
-ErrorHandler.__global__console_writeline_withpattern equ ErrorHandler+$AFE
-ErrorHandler.__global__console_writeline equ ErrorHandler+$B00
-ErrorHandler.__global__console_write equ ErrorHandler+$B04
-ErrorHandler.__global__console_writeline_formatted equ ErrorHandler+$BB0
-ErrorHandler.__global__console_write_formatted equ ErrorHandler+$BB4
+ErrorHandler.__global__error_InitConsole equ ErrorHandler+$146
+ErrorHandler.__global__errorhandler_SetupVDP equ ErrorHandler+$234
+ErrorHandler.__global__console_LoadPalette equ ErrorHandler+$A1C
+ErrorHandler.__global__console_SetPosAsXY_stack equ ErrorHandler+$A58
+ErrorHandler.__global__console_SetPosAsXY equ ErrorHandler+$A5E
+ErrorHandler.__global__console_GetPosAsXY equ ErrorHandler+$A8A
+ErrorHandler.__global__console_StartNewLine equ ErrorHandler+$AAC
+ErrorHandler.__global__console_SetBasePattern equ ErrorHandler+$AD4
+ErrorHandler.__global__console_SetWidth equ ErrorHandler+$AE8
+ErrorHandler.__global__console_WriteLine_withpattern equ ErrorHandler+$AFE
+ErrorHandler.__global__console_WriteLine equ ErrorHandler+$B00
+ErrorHandler.__global__console_Write equ ErrorHandler+$B04
+ErrorHandler.__global__console_WriteLine_formatted equ ErrorHandler+$BB0
+ErrorHandler.__global__console_Write_formatted equ ErrorHandler+$BB4
 
 
 ; ---------------------------------------------------------------
@@ -100,8 +100,8 @@ ErrorHandler.__extern__scrollconsole:
 	if ref(ErrorHandler.__extern__console_only)
 ErrorHandler.__extern__console_only:
 	dc.l	$46FC2700, $4FEFFFF2, $48E7FFFE, $47EF003C
-	jsr		ErrorHandler.__global__errorhandler_setupvdp(pc)
-	jsr		ErrorHandler.__global__error_initconsole(pc)
+	jsr		ErrorHandler.__global__errorhandler_SetupVDP(pc)
+	jsr		ErrorHandler.__global__error_InitConsole(pc)
 	dc.l	$4CDF7FFF, $487A0008, $2F2F0012, $4E7560FE
 	endc
 


### PR DESCRIPTION
If you compile with option "c+", you get undefined errors because of case mismatch.
I fixed all the error so it would compile normally under option c+.